### PR TITLE
Remove AR deprecation warning

### DIFF
--- a/lib/database_flusher/active_record/deletion_strategy.rb
+++ b/lib/database_flusher/active_record/deletion_strategy.rb
@@ -86,9 +86,11 @@ module DatabaseFlusher
       def all_tables
         # NOTE connection.tables warns on AR 5 with some adapters
         tables = ActiveSupport::Deprecation.silence { connection.tables }
+        migrations_table = Rails::VERSION::MAJOR >= 5 ? ::ActiveRecord::SchemaMigration.table_name : ::ActiveRecord::Migrator.schema_migrations_table_name
+
         tables.reject do |t|
-          (t == ::ActiveRecord::Migrator.schema_migrations_table_name) ||
-          (::ActiveRecord::Base.respond_to?(:internal_metadata_table_name) &&
+          (t == migrations_table) ||
+            (::ActiveRecord::Base.respond_to?(:internal_metadata_table_name) &&
             (t == ::ActiveRecord::Base.internal_metadata_table_name))
         end
       end

--- a/lib/database_flusher/active_record/deletion_strategy.rb
+++ b/lib/database_flusher/active_record/deletion_strategy.rb
@@ -86,10 +86,8 @@ module DatabaseFlusher
       def all_tables
         # NOTE connection.tables warns on AR 5 with some adapters
         tables = ActiveSupport::Deprecation.silence { connection.tables }
-        migrations_table = defined?(::Rails) && ::Rails::VERSION::MAJOR >= 4 ? ::ActiveRecord::SchemaMigration.table_name : ::ActiveRecord::Migrator.schema_migrations_table_name
-
         tables.reject do |t|
-          (t == migrations_table) ||
+          (t == ::ActiveRecord::SchemaMigration.table_name) ||
             (::ActiveRecord::Base.respond_to?(:internal_metadata_table_name) &&
             (t == ::ActiveRecord::Base.internal_metadata_table_name))
         end

--- a/lib/database_flusher/active_record/deletion_strategy.rb
+++ b/lib/database_flusher/active_record/deletion_strategy.rb
@@ -86,7 +86,7 @@ module DatabaseFlusher
       def all_tables
         # NOTE connection.tables warns on AR 5 with some adapters
         tables = ActiveSupport::Deprecation.silence { connection.tables }
-        migrations_table = ::Rails::VERSION::MAJOR >= 4 ? ::ActiveRecord::SchemaMigration.table_name : ::ActiveRecord::Migrator.schema_migrations_table_name
+        migrations_table = defined?(::Rails) && ::Rails::VERSION::MAJOR >= 4 ? ::ActiveRecord::SchemaMigration.table_name : ::ActiveRecord::Migrator.schema_migrations_table_name
 
         tables.reject do |t|
           (t == migrations_table) ||

--- a/lib/database_flusher/active_record/deletion_strategy.rb
+++ b/lib/database_flusher/active_record/deletion_strategy.rb
@@ -86,7 +86,7 @@ module DatabaseFlusher
       def all_tables
         # NOTE connection.tables warns on AR 5 with some adapters
         tables = ActiveSupport::Deprecation.silence { connection.tables }
-        migrations_table = Rails::VERSION::MAJOR >= 5 ? ::ActiveRecord::SchemaMigration.table_name : ::ActiveRecord::Migrator.schema_migrations_table_name
+        migrations_table = Rails::VERSION::MAJOR >= 4 ? ::ActiveRecord::SchemaMigration.table_name : ::ActiveRecord::Migrator.schema_migrations_table_name
 
         tables.reject do |t|
           (t == migrations_table) ||

--- a/lib/database_flusher/active_record/deletion_strategy.rb
+++ b/lib/database_flusher/active_record/deletion_strategy.rb
@@ -86,7 +86,7 @@ module DatabaseFlusher
       def all_tables
         # NOTE connection.tables warns on AR 5 with some adapters
         tables = ActiveSupport::Deprecation.silence { connection.tables }
-        migrations_table = Rails::VERSION::MAJOR >= 4 ? ::ActiveRecord::SchemaMigration.table_name : ::ActiveRecord::Migrator.schema_migrations_table_name
+        migrations_table = ::Rails::VERSION::MAJOR >= 4 ? ::ActiveRecord::SchemaMigration.table_name : ::ActiveRecord::Migrator.schema_migrations_table_name
 
         tables.reject do |t|
           (t == migrations_table) ||

--- a/lib/database_flusher/version.rb
+++ b/lib/database_flusher/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module DatabaseFlusher
-  VERSION = '0.3.3'.freeze
+  VERSION = '0.3.4'.freeze
 end


### PR DESCRIPTION
`DEPRECATION WARNING: schema_migrations_table_name is deprecated and will be removed from Rails 5.2`